### PR TITLE
Simplify split_on_pipes

### DIFF
--- a/piep/main.py
+++ b/piep/main.py
@@ -208,7 +208,7 @@ def split_on_pipes(cmds):
 						context.pop()
 
 			if letter == '|' and open_ctx is None:
-				cmd_array.append(cmd)
+				cmd_array.append(cmd.strip())
 				cmd = ''
 				continue
 
@@ -218,8 +218,8 @@ def split_on_pipes(cmds):
 		# note that two backslashes in a row reverts to unescaped
 		escape = letter == '\\' and not escape
 
-	cmd_array.append(cmd)
-	return [c.strip() for c in cmd_array]
+	cmd_array.append(cmd.strip())
+	return cmd_array
 
 class Mode(object):
 	__slots__ = ['desc', 'vars']


### PR DESCRIPTION
I have managed to rearrange the `split_on_pipes` algorithm so that is makes more logical sense to the reader, and is less nested. It _should_ be behaviourally equivalent to the current version.
